### PR TITLE
Handle invalid .clj files

### DIFF
--- a/test/bultitude/invalid.clj
+++ b/test/bultitude/invalid.clj
@@ -1,0 +1,9 @@
+;; This is an invalid clojure file, and is used to check bultitude has no
+;; problems with malformed source, which may be on the classpath for use
+;; as templates, etc
+
+({{somthing}})
+
+(ns bultitude.{{some node}})
+
+(def x 1)


### PR DESCRIPTION
In clojure 1.2, the reader only checks for invalid forms when the read forms are used,
so can throw outside of a read call. This commit forces any ns form to be read
completely befor ethe namespace name is exctracted.

See also http://dev.clojure.org/jira/browse/TNS-1 for discussion of the issue.
