### PR TITLE
Fix classpath to report parent classloaders first

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -69,9 +69,10 @@
      (distinct
       (mapcat
        loader-classpath
-       (take-while
-        identity
-        (iterate #(.getParent %) classloader)))))
+       (reverse
+        (take-while
+         identity
+         (iterate #(.getParent %) classloader))))))
   ([] (classpath-files (clojure.lang.RT/baseLoader))))
 
 (defn- classpath->collection [classpath]


### PR DESCRIPTION
A classloader delegates to it's parent before trying to load classes.
