### PR TITLE
fix prefix-based looukp for namespaces with dashes

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -91,7 +91,9 @@
   (cond
     (.isDirectory f) (namespaces-in-dir
                       (if prefix
-                        (io/file f (.replaceAll prefix "\\." "/"))
+                        (io/file f (-> prefix
+                                       (.replaceAll "\\." "/")
+                                       (.replaceAll "-" "_")))
                         f))
     (jar? f) (let [ns-list (namespaces-in-jar f)]
                (if prefix

--- a/test/bulti_tude/test.clj
+++ b/test/bulti_tude/test.clj
@@ -1,0 +1,1 @@
+(ns bulti-tude.test)

--- a/test/bultitude/core_test.clj
+++ b/test/bultitude/core_test.clj
@@ -17,4 +17,8 @@
   (testing "directory"
     (is (=
          #{'bultitude.core 'bultitude.core-test}
-         (set (namespaces-on-classpath :prefix "bultitude"))))))
+         (set (namespaces-on-classpath :prefix "bultitude")))))
+  (testing "dash handling in prefixes"
+    (is (=
+         #{'bulti-tude.test}
+         (set (namespaces-on-classpath :prefix "bulti-tude"))))))


### PR DESCRIPTION
Hi!

Here's a little something I noticed: if you try to look up namespaces by prefix with dashes in the prefix bultitude does not quite work right. 

Attached fix does the trick.
