### PR TITLE
New try on: https://github.com/Raynes/bultitude/pull/4

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -109,7 +109,7 @@
   [& {:keys [prefix classpath] :or {classpath (classpath-files)}}]
   (mapcat
    (partial file->namespaces prefix)
-   (-> classpath classpath->collection classpath->files)))
+   (->> classpath classpath->collection classpath->files (filter #(.canRead %)))))
 
 (defn path-for
   "Transform a namespace into a .clj file path relative to classpath root."


### PR DESCRIPTION
This commit filters namespace entries by using #(.canRead %). So it also handles unreadable jar files.
