### PR TITLE
Fix for leiningen issue #592

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -60,8 +60,7 @@
   "Returns a sequence of File paths from a classloader."
   [loader]
   (when (instance? java.net.URLClassLoader loader)
-    (map #(io/as-file %)
-         (.getURLs ^java.net.URLClassLoader loader))))
+    (map io/as-file (.getURLs ^java.net.URLClassLoader loader))))
 
 (defn classpath-files
   "Returns a sequence of File objects of the elements on the classpath."


### PR DESCRIPTION
This fixes the problem in Windows XP for lein unable to print its tasks, because the self-install path is URL-encoded.
https://github.com/technomancy/leiningen/issues/592

Tested it in leiningen preview6 on OSX and Windows XP. Both work now.
