### PR TITLE
Use a protocol for loaders that can provide their resource path

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -60,11 +60,21 @@
 (defn- split-classpath [classpath]
   (.split classpath (System/getProperty "path.separator")))
 
+
+(defprotocol ProvidesClasspath
+  "Capability to provide a pseudo-classpath as a seq of Files."
+  (get-classpath [loader]))
+
+(extend-type java.net.URLClassLoader
+  ProvidesClasspath
+  (get-classpath [loader]
+    (map io/as-file (.getURLs ^java.net.URLClassLoader loader))))
+
 (defn loader-classpath
   "Returns a sequence of File paths from a classloader."
   [loader]
-  (when (instance? java.net.URLClassLoader loader)
-    (map io/as-file (.getURLs ^java.net.URLClassLoader loader))))
+  (when (satisfies? ProvidesClasspath loader)
+    (get-classpath loader)))
 
 (defn classpath-files
   "Returns a sequence of File objects of the elements on the classpath."


### PR DESCRIPTION
This allows bultitude to be used with class loaders that aren't URLClassLoaders,
but still may have a mechanism for sharing their resource path.
