### PR TITLE
Use dynapath for reading the effective classpath from the class loader.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :description "A library for find Clojure namespaces on the classpath."
   :url "https://github.com/Raynes/bultitude"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [dynapath "0.1.0"]]
+                 [dynapath "0.2.0"]]
   :aliases {"test-all" ["with-profile" "dev,default:dev,1.3,default:dev,1.2,default" "test"]}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}})

--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -1,7 +1,7 @@
 (ns bultitude.core
   (:require [clojure.java.io :as io]
             [clojure.string :as string]
-            [dynapath.core :as dp])
+            [dynapath.util :as dp])
   (:import (java.util.jar JarFile)
            (java.util.zip ZipException)
            (java.io File BufferedReader PushbackReader InputStreamReader)
@@ -62,21 +62,14 @@
   (.split classpath (System/getProperty "path.separator")))
 
 (defn loader-classpath
-  "Returns a sequence of File paths from a classloader."
+  "Returns a sequence of File objects from a classloader."
   [loader]
-  (when (dp/readable-classpath? loader)
-    (map io/as-file (dp/classpath-urls loader))))
+  (map io/as-file (dp/classpath-urls loader)))
 
 (defn classpath-files
   "Returns a sequence of File objects of the elements on the classpath."
   ([classloader]
-     (distinct
-      (mapcat
-       loader-classpath
-       (reverse
-        (take-while
-         identity
-         (iterate #(.getParent %) classloader))))))
+     (map io/as-file (dp/all-classpath-urls classloader)))
   ([] (classpath-files (clojure.lang.RT/baseLoader))))
 
 (defn- classpath->collection [classpath]


### PR DESCRIPTION
This allows loader-classpath to work with non-URLClassLoaders. Any class loader that extends dynapath.core/DynamicClasspath and is readable can now be used with bultitude.

dynapath (https://github.com/tobias/dynapath) aims to be a common abstraction for dealing with readable or modifiable class loaders, and I have PR's pending against ritz and pomegranate to make use of it as well.

This replaces #12, which I will close directly.
