### PR TITLE
Update to latest dynapath.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :description "A library for find Clojure namespaces on the classpath."
   :url "https://github.com/Raynes/bultitude"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [dynapath "0.2.0"]]
+                 [org.tcrawley/dynapath "0.2.3"]]
   :aliases {"test-all" ["with-profile" "dev,default:dev,1.3,default:dev,1.2,default" "test"]}
   :profiles {:1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}
              :1.2 {:dependencies [[org.clojure/clojure "1.2.1"]]}})


### PR DESCRIPTION
This commit addresses two issues:
- dynapath is now org.tcrawley/dynapath, so we should update bultitude
  to prevent multiple copies ending up on the classpath
- 0.2.3 addresses an issue that allowed pomegranate to modify the boot
  classloader, which wreaked havoc. Updating bultitude may prevent a
  transitive dependency from bringing that havoc back.
