### PR TITLE
Remove unnecessary JarEntry lookup (by name) 

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -47,7 +47,7 @@
 
 (defn- ns-in-jar-entry [^JarFile jarfile ^JarEntry entry]
   (with-open [rdr (-> jarfile
-                      (.getInputStream (.getEntry jarfile (.getName entry)))
+                      (.getInputStream entry)
                       InputStreamReader.
                       BufferedReader.
                       PushbackReader.)]


### PR DESCRIPTION
The resolved `entry` was already passed as argument to the `ns-in-jar-entry` function.
