### PR TITLE
Partial support for reader conditional .cljc files.

### DIFF
--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -12,11 +12,14 @@
 
 (defn- clj? [^File f]
   (and (not (.isDirectory f))
-       (.endsWith (.getName f) ".clj")))
+       (or (.endsWith (.getName f) ".clj")
+           (.endsWith (.getName f) ".cljc"))))
 
 (defn- clj-jar-entry? [^JarEntry f]
   (and (not (.isDirectory f))
-       (.endsWith (.getName f) ".clj")))
+       (let [name (.getName f)]
+         (or (.endsWith (.getName f) ".clj")
+             (.endsWith (.getName f) ".cljc")))))
 
 (defn- jar? [^File f]
   (and (.isFile f) (.endsWith (.getName f) ".jar")))

--- a/test/bulti_tude/test_cljc.cljc
+++ b/test/bulti_tude/test_cljc.cljc
@@ -1,0 +1,1 @@
+(ns bulti-tude.test-cljc)

--- a/test/bultitude/core_test.clj
+++ b/test/bultitude/core_test.clj
@@ -5,19 +5,23 @@
 
 (deftest namespaces-in-dir-test
   (testing namespaces-in-dir
-    (is (= '(bulti-tude.test) (namespaces-in-dir "test/bulti_tude")))))
+    (is (= #{'bulti-tude.test 'bulti-tude.test-cljc}
+           (set (namespaces-in-dir "test/bulti_tude"))))))
 
 (deftest namespaces-forms-in-dir-test
   (testing namespace-forms-in-dir
-    (is (= '((ns bulti-tude.test)) (namespace-forms-in-dir "test/bulti_tude")))))
+    (is (= #{'(ns bulti-tude.test) '(ns bulti-tude.test-cljc)}
+           (set (namespace-forms-in-dir "test/bulti_tude"))))))
 
 (deftest file->namespaces-test
   (testing "on a directory with a clj in it"
-    (is (= '(bulti-tude.test) (file->namespaces nil (io/file "test/bulti_tude"))))))
+    (is (= #{'bulti-tude.test 'bulti-tude.test-cljc}
+           (set (file->namespaces nil (io/file "test/bulti_tude")))))))
 
 (deftest file->namespace-forms-test
   (testing "on a directory with a clj in it"
-    (is (= '((ns bulti-tude.test)) (file->namespace-forms nil (io/file "test/bulti_tude"))))))
+    (is (= #{'(ns bulti-tude.test) '(ns bulti-tude.test-cljc)}
+           (set (file->namespace-forms nil (io/file "test/bulti_tude")))))))
 
 (deftest namespaces-on-classpath-test
   (testing "find clojure.core"
@@ -37,7 +41,7 @@
          (set (namespaces-on-classpath :prefix "bultitude")))))
   (testing "dash handling in prefixes"
     (is (=
-         #{'bulti-tude.test}
+         #{'bulti-tude.test 'bulti-tude.test-cljc}
          (set (namespaces-on-classpath :prefix "bulti-tude"))))))
 
 (deftest namespace-forms-on-classpath-test


### PR DESCRIPTION
Clojure 1.7.0-alpha6 is out and now supports reader conditionals in .cljc files. bultitude master currently assumes clojure files are all ".clj" files, but they may now be either ".clj" or ".cljc". This change modifies the hardcoded ".clj" instances to allow ".cljc" as well, similar to what was done with clojure/tools.namespace@501976c5c61431f9914035836836ff6df2a9535e.

However, bultitude's `path-for` function cannot be modified in a backwards-compatible way to work with cljc files, because it assumes one namespace maps to one possible path, not two. It wasn't touched, so this patch does not yet offer full support for .cljc.

See also technomancy/leiningen#1827.