### PR TITLE
Support reader conditionals in ns forms

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,11 +3,11 @@
   :description "A library for find Clojure namespaces on the classpath."
   :url "https://github.com/Raynes/bultitude"
   :license {:name "Eclipse Public License 1.0"}
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.tcrawley/dynapath "0.2.3"]]
-  :aliases {"test-all" ["with-profile" "dev,1.7:dev,default:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
+  :aliases {"test-all" ["with-profile" "dev,default:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
   :profiles {:test {:resources ["test-resources"]}
-             :1.7 {:dependencies [[org.clojure/clojure "1.7.0-RC1"]]}
+             :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
              :1.3 {:dependencies [[org.clojure/clojure "1.3.0"]]}})

--- a/test/bulti_tude/cond.cljc
+++ b/test/bulti_tude/cond.cljc
@@ -1,1 +1,3 @@
-(ns bulti-tude.cond)
+(ns bulti-tude.cond
+  #?(:cljs (:require [cljs.test]))
+  )

--- a/test/bultitude/core_test.clj
+++ b/test/bultitude/core_test.clj
@@ -5,22 +5,30 @@
 
 (deftest namespaces-in-dir-test
   (testing namespaces-in-dir
-    (is (= '#{bulti-tude.cond bulti-tude.test}
+    (is (= (if *read-cond*
+             '#{bulti-tude.cond bulti-tude.test}
+             '#{bulti-tude.test})
            (set (namespaces-in-dir "test/bulti_tude"))))))
 
 (deftest namespaces-forms-in-dir-test
   (testing namespace-forms-in-dir
-    (is (= '#{(ns bulti-tude.cond) (ns bulti-tude.test)}
+    (is (= (if *read-cond*
+             '#{(ns bulti-tude.cond) (ns bulti-tude.test)}
+             '#{(ns bulti-tude.test)})
            (set (namespace-forms-in-dir "test/bulti_tude"))))))
 
 (deftest file->namespaces-test
   (testing "on a directory with a clj in it"
-    (is (= '#{bulti-tude.cond bulti-tude.test}
+    (is (= (if *read-cond*
+             '#{bulti-tude.cond bulti-tude.test}
+             '#{bulti-tude.test})
            (set (file->namespaces nil (io/file "test/bulti_tude")))))))
 
 (deftest file->namespace-forms-test
   (testing "on a directory with a clj in it"
-    (is (= '#{(ns bulti-tude.cond) (ns bulti-tude.test)}
+    (is (= (if *read-cond*
+             '#{(ns bulti-tude.cond) (ns bulti-tude.test)}
+             '#{(ns bulti-tude.test)})
            (set (file->namespace-forms nil (io/file "test/bulti_tude")))))))
 
 (deftest namespaces-on-classpath-test
@@ -40,9 +48,10 @@
          #{'bultitude.core 'bultitude.core-test}
          (set (namespaces-on-classpath :prefix "bultitude")))))
   (testing "dash handling in prefixes"
-    (is (=
-         '#{bulti-tude.cond bulti-tude.test}
-         (set (namespaces-on-classpath :prefix "bulti-tude"))))))
+    (is (= (if *read-cond*
+             '#{bulti-tude.cond bulti-tude.test}
+             '#{bulti-tude.test})
+           (set (namespaces-on-classpath :prefix "bulti-tude"))))))
 
 (deftest namespace-forms-on-classpath-test
   (testing namespace-forms-on-classpath


### PR DESCRIPTION
Upgrades default clojure dependency to 1.7 (now released) and adds full support for reader conditionals. Previous reader conditional support only allowed reading ns forms that were backwards compatible with 1.6.

Reader conditionals are processed using `:read-cond :allow` when using clojure 1.7 and above. If desired, dynamically bind `bultitude.core/*read-cond*` to change reader conditional behaviour, e.g. for reading namespace forms as cljs or preserving reader conditional forms.
