### PR TITLE
Update to dynapath 0.2.5

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/Raynes/bultitude"
   :license {:name "Eclipse Public License 1.0"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.tcrawley/dynapath "0.2.3"]]
+                 [org.tcrawley/dynapath "0.2.4"]]
   :aliases {"test-all" ["with-profile" "dev,default:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
   :profiles {:test {:resources ["test-resources"]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/Raynes/bultitude"
   :license {:name "Eclipse Public License 1.0"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.tcrawley/dynapath "0.2.4"]]
+                 [org.tcrawley/dynapath "0.2.5"]]
   :aliases {"test-all" ["with-profile" "dev,default:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
   :profiles {:test {:resources ["test-resources"]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}


### PR DESCRIPTION
This allows dynapath to at least load under Java 9.

Related to #30