### PR TITLE
Handle in ns statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ pom.xml
 .lein-failures
 pom.xml*
 target/
+.nrepl-port

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,2 @@
 language: clojure
-lein: lein2
-script: lein2 test-all
+script: lein test-all

--- a/README.markdown
+++ b/README.markdown
@@ -59,3 +59,9 @@ the issue. This library is still necessary and maintained because:
 
 New features have been added to tools.namespace recently, and when I get some time I'll see
 about porting them over.
+
+## Maintainer
+
+The original author [Raynes](https://github.com/Raynes/) died in 2016.
+
+[Timo Freiberg](https://github.com/timofreiberg) will try to keep this fork up to date and running.

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Bultitude
 
-[![Build Status](https://secure.travis-ci.org/Raynes/bultitude.png)](http://travis-ci.org/Raynes/bultitude)
+[![Build Status](https://secure.travis-ci.org/timofreiberg/bultitude.png)](http://travis-ci.org/timofreiberg/bultitude)
 
 Bultitude is a library for finding namespaces on the classpath.
 

--- a/README.markdown
+++ b/README.markdown
@@ -1,6 +1,6 @@
 # Bultitude
 
-[![Build Status](https://secure.travis-ci.org/timofreiberg/bultitude.png)](http://travis-ci.org/timofreiberg/bultitude)
+[![Build Status](https://secure.travis-ci.org/TimoFreiberg/bultitude.png)](http://travis-ci.org/TimoFreiberg/bultitude)
 
 Bultitude is a library for finding namespaces on the classpath.
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bultitude "0.2.9"
+(defproject timofreiberg/bultitude "0.2.9"
   :description "A library for finding Clojure namespaces on the classpath."
   :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}

--- a/project.clj
+++ b/project.clj
@@ -3,10 +3,12 @@
   :description "A library for find Clojure namespaces on the classpath."
   :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.tcrawley/dynapath "1.0.0"]]
-  :aliases {"test-all" ["with-profile" "dev,default:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
+  :aliases {"test-all" ["with-profile" "dev,default:dev,1.8:dev,1.7:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
   :profiles {:test {:resources ["test-resources"]}
+             :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}
+             :1.7 {:dependencies [[org.clojure/clojure "1.7.0"]]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}
              :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}
              :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}

--- a/project.clj
+++ b/project.clj
@@ -1,7 +1,7 @@
 (defproject bultitude "0.2.8"
   :min-lein-version "2.0.0"
   :description "A library for find Clojure namespaces on the classpath."
-  :url "https://github.com/Raynes/bultitude"
+  :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.tcrawley/dynapath "1.0.0"]]

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject timofreiberg/bultitude "0.2.9"
+(defproject timofreiberg/bultitude "0.2.10"
   :description "A library for finding Clojure namespaces on the classpath."
   :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject bultitude "0.2.8"
+(defproject bultitude "0.2.9"
   :description "A library for finding Clojure namespaces on the classpath."
   :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}

--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,5 @@
 (defproject bultitude "0.2.8"
-  :min-lein-version "2.0.0"
-  :description "A library for find Clojure namespaces on the classpath."
+  :description "A library for finding Clojure namespaces on the classpath."
   :url "https://github.com/timofreiberg/bultitude"
   :license {:name "Eclipse Public License 1.0"}
   :dependencies [[org.clojure/clojure "1.9.0"]

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :url "https://github.com/Raynes/bultitude"
   :license {:name "Eclipse Public License 1.0"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.tcrawley/dynapath "0.2.3"]]
+                 [org.tcrawley/dynapath "1.0.0"]]
   :aliases {"test-all" ["with-profile" "dev,default:dev,1.6:dev,1.5:dev,1.4:dev,1.3,dev" "test"]}
   :profiles {:test {:resources ["test-resources"]}
              :1.6 {:dependencies [[org.clojure/clojure "1.6.0"]]}

--- a/src/bulti_tude/cond.clj
+++ b/src/bulti_tude/cond.clj
@@ -1,0 +1,3 @@
+(ns bulti-tude.cond
+  "This ns seems to be necessary to make leiningen add \"test/bulti_tude/\" to the classpath")
+

--- a/src/bultitude/core.clj
+++ b/src/bultitude/core.clj
@@ -27,6 +27,18 @@
 (defn- jar? [^File f]
   (and (.isFile f) (.endsWith (.getName f) ".jar")))
 
+(defn- drop-quote-if-present [form]
+  (if (and (seq? form)
+           (= 'quote (first form)))
+    (second form)
+    form))
+
+(defn- drop-quote-from-in-ns-form [in-ns-form]
+  (-> in-ns-form
+      vec
+      (update 1 drop-quote-if-present)
+      seq))
+
 (defn- read-ns-form
   "Given a reader on a Clojure source file, read until an ns form is found."
   ([rdr] (read-ns-form rdr true))
@@ -38,8 +50,12 @@
                        (if ignore-unreadable?
                          ::done
                          (throw e))))]
-       (if (and (list? form) (= 'ns (first form)))
+       (cond
+         (and (list? form) (= 'ns (first form)))
          form
+         (and (list? form) (= 'in-ns (first form)))
+         (drop-quote-from-in-ns-form form)
+         :else
          (when-not (= ::done form)
            (recur rdr ignore-unreadable?))))))
 

--- a/test-resources/bultitude/in-ns/introduce-alias.clj
+++ b/test-resources/bultitude/in-ns/introduce-alias.clj
@@ -1,0 +1,2 @@
+(ns introduce-alias
+  (:require [clojure.string :as string]))

--- a/test-resources/bultitude/in-ns/use-in-ns.clj
+++ b/test-resources/bultitude/in-ns/use-in-ns.clj
@@ -1,0 +1,3 @@
+(in-ns 'introduce-alias)
+
+::string/test

--- a/test/bultitude/core_test.clj
+++ b/test/bultitude/core_test.clj
@@ -48,9 +48,7 @@
          #{'bultitude.core 'bultitude.core-test}
          (set (namespaces-on-classpath :prefix "bultitude")))))
   (testing "dash handling in prefixes"
-    (is (= (if *read-cond*
-             '#{bulti-tude.cond bulti-tude.test}
-             '#{bulti-tude.test})
+    (is (= '#{bulti-tude.cond bulti-tude.test}
            (set (namespaces-on-classpath :prefix "bulti-tude"))))))
 
 (deftest namespace-forms-on-classpath-test

--- a/test/bultitude/core_test.clj
+++ b/test/bultitude/core_test.clj
@@ -49,12 +49,17 @@
          (set (namespaces-on-classpath :prefix "bultitude")))))
   (testing "dash handling in prefixes"
     (is (= '#{bulti-tude.cond bulti-tude.test}
-           (set (namespaces-on-classpath :prefix "bulti-tude"))))))
+           (set (namespaces-on-classpath :prefix "bulti-tude")))))
+  (testing "file starting with in-ns using namespace aliased keywords"
+    (is (= '#{introduce-alias}
+           (set (namespaces-on-classpath
+                 :classpath "test-resources/bultitude/in-ns/"
+                 :ignore-unreadable? false))))))
 
 (deftest namespace-forms-on-classpath-test
   (testing namespace-forms-on-classpath
     (is (every?
-         #(= 'ns (first %))
+         #(contains? #{'ns 'in-ns} (first %))
          (namespace-forms-on-classpath)))))
 
 (defn test-doc-from-ns-form-helper


### PR DESCRIPTION
Based on https://github.com/TimoFreiberg/bultitude/pull/3

Added test
Returns the `(in-ns ...)` form instead of returning nil, since `in-ns` can also create namespaces.
This required extracting the symbol from the `(quote namespace)` cons cell in `in-ns`, which makes it a bit ugly
